### PR TITLE
include how much time loading tasks takes

### DIFF
--- a/time-grunt.js
+++ b/time-grunt.js
@@ -6,7 +6,7 @@ var table = require('text-table');
 module.exports = function (grunt) {
 	var startTime = Date.now();
 	var prevTime = Date.now();
-	var prevTaskName = '';
+	var prevTaskName = 'loading tasks';
 	var tableData = [];
 
 	grunt.util.hooker.hook(grunt.log, 'header', function () {


### PR DESCRIPTION
Sometimes just loading the tasks takes longer than the actual tasks.

![screen shot 2013-10-29 at 10 40 50 pm](https://f.cloud.github.com/assets/51505/1434091/c3e54d40-410c-11e3-8179-c9231bc900c4.png)
