### PR TITLE
Print wall-clock time at start.

### DIFF
--- a/time-grunt.js
+++ b/time-grunt.js
@@ -108,10 +108,9 @@ module.exports = function (grunt) {
 		}
 
 		// `grunt.log.header` should be unhooked above, but in some cases it's not
-		headerOrig('Elapsed time');
+		headerOrig('Execution Time');
+		grunt.log.writeln('Start: ' + startTimePretty.cyan);
+		grunt.log.writeln('Tasks:');
 		grunt.log.writeln(formatTable(tableData));
 	});
-
-	headerOrig('Start time:');
-	grunt.log.writeln(startTimePretty.cyan);
 };


### PR DESCRIPTION
It's great to have the duration of each task printed at the end, but if you also add a timestamp at the beginning of the build process, it anchors the build in time and can help when debugging build environments.
