### PR TITLE
Also trigger on SIGINT signal (fixes #4):

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -35,6 +35,13 @@ module.exports = function (grunt) {
 		setTimeout(this.async(), 21);
 	});
 
+	grunt.registerTask('testsigint', function () {
+		this.async();
+		setTimeout(function() {
+			process.emit('SIGINT');
+		}, 21);
+	});
+
 	grunt.registerTask('default', [
 		'test',
 		'test2',
@@ -43,6 +50,10 @@ module.exports = function (grunt) {
 		'This is a really long task name which is cropped in the middle'
 	]);
 
+	grunt.registerTask('sigint', [
+		'test',
+		'testsigint'
+	]);
 
 	process.on('exit', function () {
 		if (!match) {

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "url": "git://github.com/sindresorhus/time-grunt.git"
   },
   "scripts": {
-    "test": "grunt"
+    "test": "grunt && grunt sigint"
   },
   "dependencies": {
     "chalk": "~0.3.0",

--- a/time-grunt.js
+++ b/time-grunt.js
@@ -111,6 +111,10 @@ module.exports = function (grunt) {
 		});
 	}
 
+	process.on('SIGINT', function() {
+		process.exit();
+	});
+
 	process.once('timegruntexit', function (exitCode) {
 		clearInterval(interval);
 		process.exit = originalExit;


### PR DESCRIPTION
The process `exit` event does not get invoked when the user sends a SIGINT signal (CTRL-C).
We listen to the SIGINT event and triggers a normal `process.exit()`. Tests included.
