### PR TITLE
Override process.exit immediately to handle short grunt tasks.

### DIFF
--- a/time-grunt.js
+++ b/time-grunt.js
@@ -14,6 +14,7 @@ var originalExit = process.exit;
 var log = function (str) {write(str + '\n', 'utf8')};
 var write = process.stdout.write.bind(process.stdout);
 var interval = setInterval(function () {process.exit = exit}, 100);
+process.exit = exit;
 //
 
 module.exports = function (grunt) {


### PR DESCRIPTION
In some cases grunt completes before the timer fires to override
process.exit, so do it once on module load and then continue to
do so periodically.
