### PR TITLE
Allow specifying bar character through options object

### DIFF
--- a/time-grunt.js
+++ b/time-grunt.js
@@ -12,8 +12,9 @@ function log(str) {
 	write(str + '\n', 'utf8')
 }
 
-module.exports = function (grunt) {
-	var BAR_CHAR = process.platform === 'win32' ? '■' : '▇';
+module.exports = function (grunt, options) {
+	options = options || {};
+	var BAR_CHAR = options.barChar || (process.platform === 'win32' ? '■' : '▇');
 	var now = new Date();
 	var startTimePretty = dateTime();
 	var startTime = now.getTime();


### PR DESCRIPTION
Adds `options` object which allows user to override the bar character, like:

``` js
require('time-grunt')(grunt, { barChar: ':' });
```

My use case for this was needing to use a US-ASCII character during deployment. I'm overriding it based on the `no-color` option, so I guess another approach would be for `time-grunt` to check that option directly, but it doesn't necessarily mean the output has to be US-ASCII only. `barChar` seems a bit clunky as well, open to suggestions.
