### PR TITLE
Blue chalk colour for Windows hard to read

### DIFF
--- a/time-grunt.js
+++ b/time-grunt.js
@@ -108,7 +108,7 @@ module.exports = function (grunt) {
 			if (avg < 0.01 && !grunt.option('verbose')) {
 				return;
 			}
-			return [shorten(row[0]), chalk.blue(prettyMs(row[1])), chalk.blue(createBar(avg))];
+			return [shorten(row[0]), chalk.cyan(prettyMs(row[1])), chalk.cyan(createBar(avg))];
 		}).reduce(function (acc, row) {
 			if (row) {
 				acc.push(row);
@@ -117,7 +117,7 @@ module.exports = function (grunt) {
 			return acc;
 		}, []);
 
-		tableDataProcessed.push([chalk.bold.blue('Total', prettyMs(totalTime))]);
+		tableDataProcessed.push([chalk.bold.cyan('Total', prettyMs(totalTime))]);
 
 		return table(tableDataProcessed, {
 			align: [ 'l', 'r', 'l' ],


### PR DESCRIPTION
Not sure if this is a problem with my colour blindness but I'm finding the blue colour really difficult to read in Windows command prompt.

I've modified chalk.blue to chalk.cyan on line 111 and chalk.bold.blue to chalk.bold.cyan on 120 and find this much easier to read.

Is cyan an offensive colour to anyone else, could these colours even be configurable?
