### PR TITLE
Allow `--verbose` and `--v` as options that display the graphs.

### DIFF
--- a/time-grunt.js
+++ b/time-grunt.js
@@ -22,9 +22,9 @@ module.exports = function (grunt) {
 	var tableData = [];
 
 	if (argv.indexOf('--help') !== -1 ||
-	    argv.indexOf('-h') !== -1 ||
-	    argv.indexOf('--version') !== -1 ||
-	    argv.indexOf('-V') !== -1 {
+		argv.indexOf('-h') !== -1 ||
+		argv.indexOf('--version') !== -1 ||
+		argv.indexOf('-V') !== -1) {
 		return;
 	}
 


### PR DESCRIPTION
While `-v` provides a workaround to access the full task list (even of short-lived tasks), `--verbose` and `--v` quite unexpectedly disable the graph entirely.
