### PR TITLE
Save result to file

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,7 +13,7 @@ function log(str) {
 	write(str + '\n', 'utf8');
 }
 
-module.exports = function (grunt) {
+module.exports = function (grunt, options) {
 	var now = new Date();
 	var startTimePretty = dateTime();
 	var startTime = now.getTime();
@@ -140,10 +140,12 @@ module.exports = function (grunt) {
 			tableData.push([prevTaskName, diff]);
 		}
 
-		try {
-			grunt.file.write("build/report-time.json", JSON.stringify(tableData));
-		} catch (e) {
-			write("Error: can't save timing report");
+		if (options && options.exportPath) {
+			try {
+				grunt.file.write(options.exportPath, JSON.stringify(tableData));
+			} catch (e) {
+				log("Error: can't save timing report");
+			}
 		}
 
 		// `grunt.log.header` should be unhooked above, but in some cases it's not


### PR DESCRIPTION
Extension can accept options object. 
Put option `exportPath` with path to file

```
require('time-grunt')(grunt, {exportPath: "build/metrics/time.json"});
```

result saving to file

```
[["loading tasks",2],["jshint:source",6331],["jshint:test",2263]]
```
