### PR TITLE
add support of artificial 'quiet' option provided by 'quiet-grunt'

### DIFF
--- a/index.js
+++ b/index.js
@@ -23,6 +23,8 @@ module.exports = function (grunt) {
 
 	if (argv.indexOf('--help') !== -1 ||
 		argv.indexOf('-h') !== -1 ||
+		argv.indexOf('--quiet') !== -1 ||
+		argv.indexOf('-q') !== -1 ||
 		argv.indexOf('--version') !== -1 ||
 		argv.indexOf('-V') !== -1) {
 		return;


### PR DESCRIPTION
This patch makes grunt do not output (almost) anything (including output of time-grunt) when user passes '-q'/'--quiet' option that is handled by [quiet-grunt](https://www.npmjs.com/package/quiet-grunt) 