### PR TITLE
feat:add total task time to callback param

### DIFF
--- a/index.js
+++ b/index.js
@@ -134,6 +134,7 @@ module.exports = function (grunt, cb) {
 			return acc;
 		}, []);
 
+		tableData.push(['total', totalTime]);
 		tableDataProcessed.push([chalk.magenta('Total', prettyMs(totalTime))]);
 
 		return table(tableDataProcessed, {


### PR DESCRIPTION
`tableData` in `cb` doesn't include the total time, which is inconvenient to figure out the total build time.
Or are we suggesting sum up every task time in `tableData`?